### PR TITLE
禁欲の失敗報告処理を実装する

### DIFF
--- a/AbstinenceSupportPackage/Sources/Domain/ReportAbstinenceFailedInteractor/ReportAbstinenceFailedInteractor+Dependencies.swift
+++ b/AbstinenceSupportPackage/Sources/Domain/ReportAbstinenceFailedInteractor/ReportAbstinenceFailedInteractor+Dependencies.swift
@@ -1,0 +1,16 @@
+// Created by okazakishinya on 2025/02/14.
+
+import Foundation
+import Dependencies
+import Interface
+
+enum ReportAbstinenceFailedInteractorKey: DependencyKey {
+    public static let liveValue: any ReportAbstinenceFailedUseCase = ReportAbstinenceFailedInteractor()
+}
+
+extension DependencyValues {
+    public var reportAbstinenceFailedInteractorKey: any ReportAbstinenceFailedUseCase {
+        get { self[ReportAbstinenceFailedInteractorKey.self] }
+        set { self[ReportAbstinenceFailedInteractorKey.self] = newValue }
+    }
+}

--- a/AbstinenceSupportPackage/Sources/Domain/ReportAbstinenceFailedInteractor/ReportAbstinenceFailedInteractor.swift
+++ b/AbstinenceSupportPackage/Sources/Domain/ReportAbstinenceFailedInteractor/ReportAbstinenceFailedInteractor.swift
@@ -1,0 +1,19 @@
+// Created by okazakishinya on 2025/02/19.
+
+import Foundation
+import Interface
+import Dependencies
+import Infrastructure
+import Entity
+
+struct ReportAbstinenceFailedInteractor: ReportAbstinenceFailedUseCase {
+
+    @Dependency(\.keyChainHelper) var keyChainHelper
+
+    func execute(with abstinenceInformation: AbstinenceInformation) async -> AbstinenceInformation {
+        var currentInfo = abstinenceInformation
+        currentInfo.progressStatus = .penaltyUnpaidForFailure
+        keyChainHelper.save(abstinenceInformation: currentInfo)
+        return currentInfo
+    }
+}

--- a/AbstinenceSupportPackage/Sources/Interface/Domain/ReportAbstinenceFailedUseCase.swift
+++ b/AbstinenceSupportPackage/Sources/Interface/Domain/ReportAbstinenceFailedUseCase.swift
@@ -1,0 +1,9 @@
+// Created by okazakishinya on 2025/02/19.
+
+import Foundation
+import Entity
+
+/// 禁欲失敗報告された際に禁欲ステータスを更新する
+public protocol ReportAbstinenceFailedUseCase: Sendable {
+    func execute(with abstinenceInformation: AbstinenceInformation) async -> AbstinenceInformation
+}

--- a/AbstinenceSupportPackage/Tests/DomainTests/ReportAbstinenceFailedInteractorTests.swift
+++ b/AbstinenceSupportPackage/Tests/DomainTests/ReportAbstinenceFailedInteractorTests.swift
@@ -1,0 +1,32 @@
+// Created by okazakishinya on 2025/02/14.
+
+import Foundation
+import Testing
+import Dependencies
+@testable import Domain
+@testable import Entity
+@testable import Common
+@testable import TestHelper
+
+struct ReportAbstinenceFailedInteractorTests {
+
+    var interactor: ReportAbstinenceFailedInteractor!
+    let keyChainHelperStub: KeyChainHelperStub
+    var testEntity = AbstinenceInformation(title: "sample", detail: nil, targetDays: 0, scheduledReportDate: Date(), penaltyInfo: .freePenaltyInfo(), startDate: Date())
+    
+    init() {
+        self.keyChainHelperStub = KeyChainHelperStub()
+        interactor = withDependencies {
+            $0.keyChainHelper = keyChainHelperStub
+        } operation: {
+            ReportAbstinenceFailedInteractor()
+        }
+    }
+    
+    @Test("失敗ステータスに更新されていることを確認")
+    func updateFailureStatus() async throws {
+        let result = await interactor.execute(with: testEntity)
+        #expect(result.progressStatus == .penaltyUnpaidForFailure)
+        #expect(keyChainHelperStub.abstinenceInformation == result)
+    }
+}


### PR DESCRIPTION
## 対応内容

* 禁欲の失敗報告処理を担う ReportAbstinenceFailedInteractor を作成
    * 実行後、禁欲ステータスを「失敗 `penaltyUnpaidForFailure` 」に更新

## 関連Issue

Close #49 