### PR TITLE
【Bug】トップ画面でフラグを切り替えた際にボタンの活性状態が更新されない事象を修正

### DIFF
--- a/AbstinenceSupportPackage/Sources/Presentation/Top/TopView.swift
+++ b/AbstinenceSupportPackage/Sources/Presentation/Top/TopView.swift
@@ -22,6 +22,7 @@ struct TopView<ViewModel: TopViewModelProtocol>: View {
             if viewModel.isCompletedInitialization {
                 contentView
                     .disabled(viewModel.isProcessing)
+                    .animation(.default, value: viewModel.isProcessing)
             }
         }
         .overlay {

--- a/AbstinenceSupportPackage/Sources/Presentation/Top/TopViewModel.swift
+++ b/AbstinenceSupportPackage/Sources/Presentation/Top/TopViewModel.swift
@@ -14,6 +14,7 @@ public final class TopViewModel: TopViewModelProtocol {
     @Published public var abstinenceInformation: AbstinenceInformation
     @Published public var isCompletedInitialization = false
     @Published public var isPresentedAlert = false
+    @Published public var isProcessing: Bool = false
     public var alertInfo: AlertInfo? {
         didSet {
             self.isPresentedAlert = alertInfo != nil
@@ -27,7 +28,6 @@ public final class TopViewModel: TopViewModelProtocol {
         return true
     }
     public var restrictiveAbortState: RestrictiveAbortState = .unrestricted
-    public var isProcessing: Bool = false
     private var isExecutedSetup = false
 
     @Dependency(\.setupAbstinenceInteractor) var setupAbstinenceInteractor


### PR DESCRIPTION
## 対応内容

* トップ画面で達成報告を行った後、ボタンの活性状態が切り替わらなかった事象を修正
    * 対象プロパティに `@Published` を付与